### PR TITLE
DTS-22633 added filterData call on tab navigation UI 

### DIFF
--- a/UI/src/app/dashboard/filter/filter.component.spec.ts
+++ b/UI/src/app/dashboard/filter/filter.component.spec.ts
@@ -356,13 +356,15 @@ describe('FilterComponent', () => {
 
   it('should get filter data on load', () => {
     spyOn(sharedService, 'getFilterData').and.returnValue(fakeFilterData);
+    spyOn(httpService,'getFilterData').and.returnValue(of(fakeFilterData));
     component.previousType = false;
     component.kanban = false;
     component.selectedTab = '';
     component.initFlag = false;
     const spy = spyOn(component, 'processFilterData');
     component.getFilterDataOnLoad();
-    expect(spy).toHaveBeenCalledWith(fakeFilterData);
+    fixture.detectChanges();
+    expect(spy).toHaveBeenCalled();
   });
 
   it('should get filter data on load', () => {

--- a/UI/src/app/dashboard/filter/filter.component.ts
+++ b/UI/src/app/dashboard/filter/filter.component.ts
@@ -291,15 +291,11 @@ export class FilterComponent implements OnInit {
         this.selectedFilterData.kanban = this.kanban;
         this.selectedFilterData['sprintIncluded'] = this.selectedTab?.toLowerCase() == 'iteration' ? ['CLOSED', 'ACTIVE'] : ['CLOSED'];
         const filterData = this.service.getFilterData();
-        if (!Object.keys(filterData).length || (this.previousType !== this.kanban) || this.selectedTab?.toLowerCase() == 'iteration' || this.selectedTab?.toLowerCase() == 'backlog' || this.initFlag) {
             this.filterKpiRequest = this.httpService.getFilterData(this.selectedFilterData)
                 .subscribe(filterApiData => {
                     this.processFilterData(filterApiData);
                     this.initFlag = false;
                 });
-        } else {
-            this.processFilterData(filterData);
-        }
     }
 
     processFilterData(filterData) {


### PR DESCRIPTION
https://tools.publicis.sapient.com/jira/browse/DTS-22633 for Squad defects, whenever we switched tabs from iteration and knowhow , earlier we did not call again filter data api call so that active sprint squad will appear on the knowhow board. 