### PR TITLE
Cache policy rules - wrong PR

### DIFF
--- a/common/src/main/java/com/publicissapient/kpidashboard/common/constant/CommonConstant.java
+++ b/common/src/main/java/com/publicissapient/kpidashboard/common/constant/CommonConstant.java
@@ -319,6 +319,7 @@ public final class CommonConstant {
 	public static final String JIRA = "Jira";
 
 	public static final String REPO = "Repo";
+	public static final String ACTION_POLICY_RULES_CACHE = "actionPolicyRules";
 
 	private CommonConstant() {
 

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/auth/AuthProperties.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/auth/AuthProperties.java
@@ -52,6 +52,8 @@ public class AuthProperties {// NOPMD
 	private String secret;
 	private String ldapUserDnPattern;
 	private String ldapServerUrl;
+
+	private String centralAuthBaseURL;
 	private List<AuthType> authenticationProviders = Lists.newArrayList();
 
 	private String adDomain;
@@ -123,6 +125,24 @@ public class AuthProperties {// NOPMD
 	 */
 	public void setLdapUserDnPattern(String ldapUserDnPattern) {
 		this.ldapUserDnPattern = ldapUserDnPattern;
+	}
+
+	/**
+	 * Get central auth base url
+	 *
+	 * @return
+	 */
+	public String getCentralAuthBaseURL() {
+		return centralAuthBaseURL;
+	}
+
+	/**
+	 * Set central auth base url
+	 * 
+	 * @param centralAuthBaseURL
+	 */
+	public void setCentralAuthBaseURL(String centralAuthBaseURL) {
+		this.centralAuthBaseURL = centralAuthBaseURL;
 	}
 
 	/**

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/auth/service/AuthNAuthService.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/auth/service/AuthNAuthService.java
@@ -1,0 +1,25 @@
+package com.publicissapient.kpidashboard.apis.auth.service;
+
+import com.publicissapient.kpidashboard.apis.model.ServiceResponse;
+
+/**
+ * aksshriv1
+ */
+public interface AuthNAuthService {
+
+	/**
+	 * Check policies by resources in central auth
+	 * 
+	 * @param apiKey
+	 * @return
+	 */
+	ServiceResponse checkPoliciesByResource(String apiKey);
+
+	/**
+	 * fetch policies by resources from central auth
+	 * 
+	 * @param apiKey
+	 * @return
+	 */
+	ServiceResponse fetchActionPolicyByResource(String apiKey);
+}

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/auth/service/AuthNAuthServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/auth/service/AuthNAuthServiceImpl.java
@@ -1,0 +1,101 @@
+package com.publicissapient.kpidashboard.apis.auth.service;
+
+/**
+ * aksshriv1
+ */
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.publicissapient.kpidashboard.apis.auth.AuthProperties;
+import com.publicissapient.kpidashboard.apis.model.ServiceResponse;
+import com.publicissapient.kpidashboard.apis.util.CommonUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class AuthNAuthServiceImpl implements AuthNAuthService {
+
+	private static final String CHECK_POLICY_END_POINT = "PSKnowHow/policies/check";
+	private static final String FETCH_POLICY_END_POINT = "PSKnowHow/policies";
+	private static final String HTTP_ENTITY = "httpEntity {}";
+	private static final String RESPONSE = "response {}";
+	private static final String DATA_FOUND = "data found";
+	private static final String FETCHED_RESPONSE = "fetched response {}";
+	private static final String ERROR_CODE = "Error while fetching from {}. with status {}";
+	private static final String ERROR_MESSAGE = "Error while fetching from {}:  {}";
+
+	@Autowired
+	AuthProperties authProperties;
+	@Autowired
+	private RestTemplate restTemplate;
+
+	@Override
+	public ServiceResponse checkPoliciesByResource(String apiKey) {
+		log.info("checking Action Policy Rules for KnowHow");
+		String actionPolicyUrl = getCheckActionPolicyUrl(CHECK_POLICY_END_POINT);
+		HttpEntity<?> httpEntity = new HttpEntity<>(CommonUtils.getHeaders(apiKey, true));
+		log.info(HTTP_ENTITY, httpEntity);
+		ParameterizedTypeReference<ServiceResponse> typeReference = new ParameterizedTypeReference<ServiceResponse>() {
+		};
+		return getAuthNAuthResponse(restTemplate.exchange(actionPolicyUrl, HttpMethod.POST, httpEntity, typeReference),
+				actionPolicyUrl);
+	}
+
+	@Override
+	public ServiceResponse fetchActionPolicyByResource(String apiKey) {
+		log.info("fetching Action Policy Rules from central auth");
+		String actionPolicyUrl = getCheckActionPolicyUrl(FETCH_POLICY_END_POINT);
+		HttpEntity<?> httpEntity = new HttpEntity<>(CommonUtils.getHeaders(apiKey, true));
+		log.info(HTTP_ENTITY, httpEntity);
+		ParameterizedTypeReference<ServiceResponse> typeReference = new ParameterizedTypeReference<ServiceResponse>() {
+		};
+		return getAuthNAuthResponse(restTemplate.exchange(actionPolicyUrl, HttpMethod.GET, httpEntity, typeReference),
+				actionPolicyUrl);
+	}
+
+	/**
+	 * This method returns Action Policy url
+	 * 
+	 * @return Action Policy URL
+	 */
+	private String getCheckActionPolicyUrl(String checkPolicyEndPoint) {
+
+		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(authProperties.getCentralAuthBaseURL());
+		uriBuilder.path("/api/");
+		uriBuilder.path(checkPolicyEndPoint);
+		return uriBuilder.toUriString();
+	}
+
+	/**
+	 * 
+	 * @param responseEntity
+	 * @param url
+	 * @return
+	 */
+	public ServiceResponse getAuthNAuthResponse(ResponseEntity<ServiceResponse> responseEntity, String url) {
+		ServiceResponse fetchDataResponse = new ServiceResponse();
+		try {
+			log.info(RESPONSE, responseEntity);
+			if (responseEntity.getStatusCode() == HttpStatus.OK) {
+				log.info(DATA_FOUND);
+				fetchDataResponse = responseEntity.getBody();
+				log.info(FETCHED_RESPONSE, fetchDataResponse);
+			} else {
+				String statusCode = responseEntity.getStatusCode().toString();
+				log.error(ERROR_CODE, url, statusCode);
+			}
+		} catch (Exception exception) {
+			log.error(ERROR_MESSAGE, url, exception.getMessage());
+		}
+		return fetchDataResponse;
+	}
+}

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/common/service/CacheService.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/common/service/CacheService.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
+import com.publicissapient.kpidashboard.apis.model.ServiceResponse;
 import com.publicissapient.kpidashboard.common.model.application.AdditionalFilterCategory;
 import com.publicissapient.kpidashboard.common.model.application.HierarchyLevel;
 
@@ -100,5 +101,7 @@ public interface CacheService {
 	Map<String, HierarchyLevel> getFullKanbanHierarchyLevelMap();
 
 	Map<String, AdditionalFilterCategory> getAdditionalFilterHierarchyLevel();
+
+	ServiceResponse getActionPoliciesFromCache(String authCookie);
 
 }

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/model/ServiceResponse.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/model/ServiceResponse.java
@@ -25,6 +25,9 @@ public class ServiceResponse extends BaseResponse {
 
 	private Object data;
 
+	public ServiceResponse() {
+	}
+
 	/**
 	 * 
 	 * @param isSuccess

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/util/CommonUtils.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/util/CommonUtils.java
@@ -41,6 +41,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
 
 import com.publicissapient.kpidashboard.apis.constant.Constant;
 import com.publicissapient.kpidashboard.apis.enums.KPISource;
@@ -506,8 +507,11 @@ public final class CommonUtils {
 
 	/**
 	 * Method to get next working date i.e excluding sat sun
-	 * @param currentDate currentDate
-	 * @param daysToAdd count of days to add
+	 * 
+	 * @param currentDate
+	 *            currentDate
+	 * @param daysToAdd
+	 *            count of days to add
 	 * @return
 	 */
 	public static java.time.LocalDate getNextWorkingDate(java.time.LocalDate currentDate, long daysToAdd) {
@@ -520,4 +524,22 @@ public final class CommonUtils {
 		return resultDate;
 	}
 
+	/**
+	 * 
+	 * @param apiKey
+	 * @param usingBasicAuth
+	 * @return
+	 */
+
+	public static HttpHeaders getHeaders(String apiKey, boolean usingBasicAuth) {
+		HttpHeaders headers = new HttpHeaders();
+		if (apiKey != null && !apiKey.isEmpty()) {
+			if (usingBasicAuth) {
+				headers.set("x-api-key", apiKey);
+			} else {
+				headers.add("x-api-key", apiKey);
+			}
+		}
+		return headers;
+	}
 }


### PR DESCRIPTION
In this feature we are fetching action policy rules data from central auth DB and storing it in cache object at client side and also clearing the cache TTL based. 