### PR TITLE
DTS-31691: Time zone conversion issue fix

### DIFF
--- a/UI/src/app/dashboard/filter/filter.component.ts
+++ b/UI/src/app/dashboard/filter/filter.component.ts
@@ -1243,9 +1243,9 @@ export class FilterComponent implements OnInit, OnDestroy {
       if (obj) {
         let d;
         if (type == 'start') {
-          d = new Date(obj[startDateField]);
+          d = new Date(obj[startDateField].split('T')[0]);
         } else {
-          d = new Date(obj[endDateField]);
+          d = new Date(obj[endDateField].split('T')[0]);
         }
         dateString = [this.pad(d.getDate()), this.pad(monthNames[d.getMonth()]), d.getFullYear()].join('/');
       }


### PR DESCRIPTION
Twice Time Zone conversion is root cause for it which add 5hr to it, once coming from Jira then our own conversion to DD/MMM/YYYY. which in total add 10hr to time.

Fix applied : During conversion of “2024-01-17T15:46:32.000Z” to DD/MMM/YYYY format, removing the time zone data i.e taking only “2024-01-17” which will convert into 17/Jan/2024.

[Ticket Line](https://publicissapient.atlassian.net/browse/DTS-31691)