### PR TITLE
DTS-31538_DCTP_ExclusionCriteria

### DIFF
--- a/common/src/main/java/com/publicissapient/kpidashboard/common/model/application/FieldMapping.java
+++ b/common/src/main/java/com/publicissapient/kpidashboard/common/model/application/FieldMapping.java
@@ -199,6 +199,7 @@ public class FieldMapping extends BasicModel {
 
 	private List<String> rootCauseValue;
 	private List<String> excludeRCAFromFTPR;
+	private List<String> excludeRCAFromKPI163;
 	private List<String> includeRCAForKPI82;
 	private List<String> includeRCAForKPI135;
 	private List<String> includeRCAForKPI14;

--- a/common/src/main/java/com/publicissapient/kpidashboard/common/model/application/dto/FieldMappingDTO.java
+++ b/common/src/main/java/com/publicissapient/kpidashboard/common/model/application/dto/FieldMappingDTO.java
@@ -193,6 +193,7 @@ public class FieldMappingDTO extends BasicModel {
 
     private List<String> rootCauseValue;
     private List<String> excludeRCAFromFTPR; // test done
+    private List<String> excludeRCAFromKPI163;
     private List<String> includeRCAForKPI82;
     private List<String> includeRCAForKPI135;
     private List<String> includeRCAForKPI14;

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/enums/FieldMappingEnum.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/enums/FieldMappingEnum.java
@@ -195,7 +195,7 @@ public enum FieldMappingEnum {
 	KPI156("Lead Time For Change", KPISource.JIRA.name(),
 			Arrays.asList("leadTimeConfigRepoTool", "toBranchForMRKPI156" , "jiraDodKPI156" , "jiraIssueTypeKPI156","thresholdValueKPI156")),
 
-	KPI163("Defect by Testing Phase", KPISource.JIRA.name(), Collections.singletonList("jiraDodKPI163")),
+	KPI163("Defect by Testing Phase", KPISource.JIRA.name(), Arrays.asList("jiraDodKPI163", "excludeRCAFromKPI163")),
 
 	KPI150("Release BurnUp", KPISource.JIRA.name(), Arrays.asList("startDateCountKPI150","populateByDevDoneKPI150","jiraDevDoneStatusKPI150")),
 

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseDefectByTestPhaseImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseDefectByTestPhaseImpl.java
@@ -161,13 +161,13 @@ public class ReleaseDefectByTestPhaseImpl extends JiraKPIService<Integer, List<O
 			List<JiraIssue> releaseIssues) {
 		Map<String, Set<String>> projectWiseRCA = new HashMap<>();
 		KpiHelperService.addRCAProjectWise(projectWiseRCA, leafNode, fieldMapping.getExcludeRCAFromKPI163());
-		List<JiraIssue> notFTPRDefects = new ArrayList<>();
+		List<JiraIssue> rcaFreeIssues = new ArrayList<>();
 		releaseIssues.stream().filter(jiraIssue -> {
 			Set<String> rcas = projectWiseRCA.getOrDefault(jiraIssue.getBasicProjectConfigId(), Collections.emptySet());
 			return rcas.isEmpty()
 					|| jiraIssue.getRootCauseList().stream().noneMatch(rc -> rcas.contains(rc.toLowerCase()));
-		}).forEach(notFTPRDefects::add);
-		return notFTPRDefects;
+		}).forEach(rcaFreeIssues::add);
+		return rcaFreeIssues;
 	}
 
 	private void populateExcelDataObject(String requestTrackerId, List<KPIExcelData> excelData,

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseDefectByTestPhaseImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseDefectByTestPhaseImpl.java
@@ -16,6 +16,7 @@
 package com.publicissapient.kpidashboard.apis.jira.scrum.service.release;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.publicissapient.kpidashboard.apis.appsetting.service.ConfigHelperService;
+import com.publicissapient.kpidashboard.apis.common.service.impl.KpiHelperService;
 import com.publicissapient.kpidashboard.apis.enums.Filters;
 import com.publicissapient.kpidashboard.apis.enums.KPICode;
 import com.publicissapient.kpidashboard.apis.enums.KPIExcelColumn;
@@ -138,9 +140,34 @@ public class ReleaseDefectByTestPhaseImpl extends JiraKPIService<Integer, List<O
 			FieldMapping fieldMapping = configHelperService.getFieldMappingMap()
 					.get(leafNode.getProjectFilter().getBasicProjectConfigId());
 			List<JiraIssue> releaseIssues = getFilteredReleaseJiraIssuesFromBaseClass(fieldMapping);
-			resultListMap.put(TOTAL_ISSUES, releaseIssues);
+			List<JiraIssue> rcaExcludedIssues = excludeRCAMatchingIssues(leafNode, fieldMapping, releaseIssues);
+			resultListMap.put(TOTAL_ISSUES, rcaExcludedIssues);
 		}
 		return resultListMap;
+	}
+
+	/**
+	 * to remove jiraissue containing specified rcas
+	 * 
+	 * @param leafNode
+	 *            leafNode
+	 * @param fieldMapping
+	 *            fieldMapping
+	 * @param releaseIssues
+	 *            releaseIssues
+	 * @return excluded jiraissue
+	 */
+	private List<JiraIssue> excludeRCAMatchingIssues(Node leafNode, FieldMapping fieldMapping,
+			List<JiraIssue> releaseIssues) {
+		Map<String, Set<String>> projectWiseRCA = new HashMap<>();
+		KpiHelperService.addRCAProjectWise(projectWiseRCA, leafNode, fieldMapping.getExcludeRCAFromKPI163());
+		List<JiraIssue> notFTPRDefects = new ArrayList<>();
+		releaseIssues.stream().filter(jiraIssue -> {
+			Set<String> rcas = projectWiseRCA.getOrDefault(jiraIssue.getBasicProjectConfigId(), Collections.emptySet());
+			return rcas.isEmpty()
+					|| jiraIssue.getRootCauseList().stream().noneMatch(rc -> rcas.contains(rc.toLowerCase()));
+		}).forEach(notFTPRDefects::add);
+		return notFTPRDefects;
 	}
 
 	private void populateExcelDataObject(String requestTrackerId, List<KPIExcelData> excelData,

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/rollback/release_830/DCTPEnhnc.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/rollback/release_830/DCTPEnhnc.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright 2014 CapitalOne, LLC.
+ * Further development Copyright 2022 Sapient Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.publicissapient.kpidashboard.apis.mongock.rollback.release_830;
+
+import java.util.Collections;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import com.mongodb.client.MongoCollection;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+/**
+ * add rca exclusion field mapping
+ *
+ * @author shi6
+ */
+@ChangeUnit(id = "r_dctp_enhnc", order = "08332", author = "shi6", systemVersion = "8.3.3")
+public class DCTPEnhnc {
+	private final MongoTemplate mongoTemplate;
+	private static final String FIELD_NAME = "fieldName";
+
+	public DCTPEnhnc(MongoTemplate mongoTemplate) {
+		this.mongoTemplate = mongoTemplate;
+	}
+
+	@Execution
+	public void execution() {
+		MongoCollection<Document> fieldMappingStructure = mongoTemplate.getCollection("field_mapping_structure");
+		fieldMappingStructure.deleteMany(
+				new Document(FIELD_NAME, new Document("$in", Collections.singletonList("excludeRCAFromKPI163"))));
+
+	}
+
+	@RollbackExecution
+	public void rollback() {
+		// no implementation required
+	}
+}

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_830/DCTPEnhnc.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_830/DCTPEnhnc.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2014 CapitalOne, LLC.
+ * Further development Copyright 2022 Sapient Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.publicissapient.kpidashboard.apis.mongock.upgrade.release_830;
+
+import java.util.Collections;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import com.mongodb.client.MongoCollection;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+/**
+ * add rca exclusion field mapping
+ * 
+ * @author shi6
+ */
+@ChangeUnit(id = "dctp_enhnc", order = "8332", author = "shi6", systemVersion = "8.3.3")
+public class DCTPEnhnc {
+	public static final String ORDER = "order";
+	private final MongoTemplate mongoTemplate;
+	private static final String DEFINITION = "definition";
+	private static final String FIELD_NAME = "fieldName";
+
+	public DCTPEnhnc(MongoTemplate mongoTemplate) {
+		this.mongoTemplate = mongoTemplate;
+	}
+
+	@Execution
+	public void execution() {
+		Document excludeRCA = new Document(FIELD_NAME, "excludeRCAFromKPI163")
+				.append("fieldLabel", "Root cause values to be excluded").append("fieldType", "chips")
+				.append("section", "Defects Mapping").append("tooltip",
+						new Document(DEFINITION, "Root cause reasons for defects which are to be excluded."));
+
+		mongoTemplate.getCollection("field_mapping_structure").insertOne(excludeRCA);
+	}
+
+	@RollbackExecution
+	public void rollback() {
+		MongoCollection<Document> fieldMappingStructure = mongoTemplate.getCollection("field_mapping_structure");
+		fieldMappingStructure
+				.deleteMany(new Document(FIELD_NAME, new Document("$in", Collections.singletonList("excludeRCAFromKPI163"))));
+	}
+}

--- a/customapi/src/main/resources/json/mongock/default/field_mapping_structure.json
+++ b/customapi/src/main/resources/json/mongock/default/field_mapping_structure.json
@@ -3025,5 +3025,14 @@
     "tooltip": {
       "definition": "Target KPI value denotes the bare minimum a project should maintain for a KPI. User should just input the number and the unit like percentage, hours will automatically be considered. If the threshold is empty, then a common target KPI line will be shown"
     }
+  },
+  {
+    "fieldName" : "excludeRCAFromKPI163" ,
+    "fieldLabel" : "Root cause values to be excluded" ,
+    "fieldType" : "chips" ,
+    "section" : "Defects Mapping" ,
+    "tooltip" : {
+      "definition" : "Root cause reasons for defects which are to be excluded."
+    }
   }
 ]

--- a/customapi/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseDefectByTestPhaseImplTest.java
+++ b/customapi/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseDefectByTestPhaseImplTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +77,22 @@ public class ReleaseDefectByTestPhaseImplTest {
 		TreeAggregatorDetail treeAggregatorDetail = KPIHelperUtil.getTreeLeafNodesGroupedByFilter(kpiRequest,
 				accountHierarchyDataList, new ArrayList<>(), "hierarchyLevelOne", 5);
 		String kpiRequestTrackerId = "Jira-Excel-QADD-track001";
+		when(configHelperService.getFieldMappingMap()).thenReturn(fieldMappingMap);
+		when(jiraService.getJiraIssuesForSelectedRelease()).thenReturn(bugList);
+		when(cacheService.getFromApplicationCache(Constant.KPI_REQUEST_TRACKER_ID_KEY + KPISource.JIRA.name()))
+				.thenReturn(kpiRequestTrackerId);
+		KpiElement kpiElement = releaseDefectByTestingPhaseImpl.getKpiData(kpiRequest, kpiRequest.getKpiList().get(0),
+				treeAggregatorDetail);
+		assertNotNull(kpiElement.getTrendValueList());
+	}
+
+	@Test
+	public void getKpiData_withExclusionCriteria() throws ApplicationException {
+		TreeAggregatorDetail treeAggregatorDetail = KPIHelperUtil.getTreeLeafNodesGroupedByFilter(kpiRequest,
+				accountHierarchyDataList, new ArrayList<>(), "hierarchyLevelOne", 5);
+		String kpiRequestTrackerId = "Jira-Excel-QADD-track001";
+		List<FieldMapping> values = new ArrayList<>( fieldMappingMap.values());
+		values.get(0).setExcludeRCAFromKPI163(Arrays.asList("CODE ISSUE"));
 		when(configHelperService.getFieldMappingMap()).thenReturn(fieldMappingMap);
 		when(jiraService.getJiraIssuesForSelectedRelease()).thenReturn(bugList);
 		when(cacheService.getFromApplicationCache(Constant.KPI_REQUEST_TRACKER_ID_KEY + KPISource.JIRA.name()))


### PR DESCRIPTION
defect count by testing phase a kpi of release dashboard, counts all the defects without any filter, in this enhancement- we have added a configuration at kpi level to exclude defects that match the rca field. 

publicissapient.atlassian.net/browse/DTS-31538