### PR TITLE
DTS-32181-Fixed the intermittent issue occurring in global mapping.

### DIFF
--- a/UI/src/app/config/project-config/tool-menu/tool-menu.component.spec.ts
+++ b/UI/src/app/config/project-config/tool-menu/tool-menu.component.spec.ts
@@ -105,11 +105,11 @@ describe('ToolMenuComponent', () => {
     toolsReq.flush(toolsData);
 
     const jiraOrAzure = toolsData['data'].filter(tool => tool.toolName === 'Jira' || tool.toolName === 'Azure');
-    expect(component.disableSwitch).toBeTrue();
     if (jiraOrAzure.length) {
       const mappingsReq = httpMock.expectOne(`${baseUrl}/api/tools/${jiraOrAzure[0].id}/fieldMapping`);
       expect(mappingsReq.request.method).toBe('GET');
       mappingsReq.flush(mappingData);
+      expect(component.disableSwitch).toBeTrue();
     }
     if (component.isAssigneeSwitchChecked) {
       expect(component.isAssigneeSwitchDisabled).toBeTruthy();
@@ -449,5 +449,5 @@ describe('ToolMenuComponent', () => {
     component.ngOnInit();
     expect(component.tools.length).toEqual(1);
   })
-  
+
 });

--- a/UI/src/app/config/project-config/tool-menu/tool-menu.component.ts
+++ b/UI/src/app/config/project-config/tool-menu/tool-menu.component.ts
@@ -97,10 +97,10 @@ export class ToolMenuComponent implements OnInit {
             };
             this.projectTypeChange(fakeEvent, false);
             this.selectedType = jiraOrAzure[0].toolName === 'Azure';
-            this.disableSwitch = true;
             this.http.getFieldMappings(jiraOrAzure[0].id).subscribe(mappings => {
               if (mappings && mappings['success']) {
                 this.sharedService.setSelectedFieldMapping(mappings['data']);
+                this.disableSwitch = true;
               } else {
                 this.sharedService.setSelectedFieldMapping(null);
               }


### PR DESCRIPTION
Sometimes the /fieldMapping call takes time to return the response. But on the UI side Mappings button is always in enabled mode. Even if there is no response for the mapping page, we can click the button and enter inside the page which shows no data as we have not received the data yet.

So, here we have disabled the button until the fieldMapping response does not come. Once the response is returned, we enable it so that the user can enter the page.