### PR TITLE
DTS-38553_Show_Hide

### DIFF
--- a/common/src/main/java/com/publicissapient/kpidashboard/common/repository/rbac/UserInfoCustomRepository.java
+++ b/common/src/main/java/com/publicissapient/kpidashboard/common/repository/rbac/UserInfoCustomRepository.java
@@ -32,5 +32,5 @@ public interface UserInfoCustomRepository {
 	 * @param basicProjectConfigId basicProjectConfigId
 	 * @return List<UserInfo>
 	 */
-	List<UserInfo> findAdminUserOfProject(String basicProjectConfigId);
+	List<UserInfo> findAdminUserOfProject(List<String> basicProjectConfigId);
 }

--- a/common/src/main/java/com/publicissapient/kpidashboard/common/repository/rbac/UserInfoCustomRepositoryImpl.java
+++ b/common/src/main/java/com/publicissapient/kpidashboard/common/repository/rbac/UserInfoCustomRepositoryImpl.java
@@ -54,13 +54,13 @@ public class UserInfoCustomRepositoryImpl implements UserInfoCustomRepository {
 	 * @return List<UserInfo>
 	 */
 	@Override
-	public List<UserInfo> findAdminUserOfProject(String basicProjectConfigId) {
+	public List<UserInfo> findAdminUserOfProject(List<String> basicProjectConfigId) {
 
 		Query query = new Query();
 
 		Criteria accessCriteria = Criteria.where("projectsAccess").elemMatch(
 				Criteria.where("role").in("ROLE_PROJECT_ADMIN", "ROLE_SUPERADMIN").and("accessNodes").elemMatch(Criteria
-						.where("accessLevel").is("project").and("accessItems.itemId").is(basicProjectConfigId)));
+						.where("accessLevel").is("project").and("accessItems.itemId").in(basicProjectConfigId)));
 
 		query.addCriteria(accessCriteria);
 

--- a/common/src/test/java/com/publicissapient/kpidashboard/common/repository/rbac/UserInfoCustomRepositoryImplTest.java
+++ b/common/src/test/java/com/publicissapient/kpidashboard/common/repository/rbac/UserInfoCustomRepositoryImplTest.java
@@ -54,7 +54,7 @@ public class UserInfoCustomRepositoryImplTest {
 
 		when(operations.find(any(Query.class), eq(UserInfo.class))).thenReturn(Collections.emptyList());
 		// Call the method and assert the result
-		List<UserInfo> result = userInfoCustomRepository.findAdminUserOfProject("basicConfigId");
+		List<UserInfo> result = userInfoCustomRepository.findAdminUserOfProject(List.of("basicConfigId"));
 		userInfoCustomRepository.findByProjectAccess("basicConfigId");
 
 		// Assert the result or perform further verifications

--- a/customapi/src/test/java/com/publicissapient/kpidashboard/apis/userboardconfig/service/UserBoardConfigServiceImplTest.java
+++ b/customapi/src/test/java/com/publicissapient/kpidashboard/apis/userboardconfig/service/UserBoardConfigServiceImplTest.java
@@ -35,6 +35,10 @@ import java.util.stream.Collectors;
 
 import com.publicissapient.kpidashboard.apis.model.ServiceResponse;
 import com.publicissapient.kpidashboard.apis.mongock.data.FiltersDataFactory;
+import com.publicissapient.kpidashboard.common.model.rbac.AccessItem;
+import com.publicissapient.kpidashboard.common.model.rbac.AccessNode;
+import com.publicissapient.kpidashboard.common.model.rbac.ProjectsAccess;
+import com.publicissapient.kpidashboard.common.model.rbac.UserInfo;
 import com.publicissapient.kpidashboard.common.repository.application.AdditionalFilterCategoryRepository;
 import com.publicissapient.kpidashboard.common.repository.application.FiltersRepository;
 import org.junit.Before;
@@ -380,10 +384,68 @@ public class UserBoardConfigServiceImplTest {
 				.filter(master -> (!master.getKanban() && "Backlog".equalsIgnoreCase(master.getKpiCategory())))
 				.collect(Collectors.toList()));
 		when(kpiCategoryMappingRepository.findAll()).thenReturn(kpiCategoryMappingList);
+		when(userInfoCustomRepository.findAdminUserOfProject(anyList())).thenReturn(createDummyAdminUsers());
 		UserBoardConfigDTO userBoardConfigDTO = userBoardConfigServiceImpl.getUserBoardConfig(listOfReqProjects);
+
+
 		assertEquals(userBoardConfigDTO.getScrum().get(2).getKpis().size(), 6, "Previously 4 kpis now 5");
 		assertNotNull(userBoardConfigDTO);
 		assertEquals(userBoardConfigDTO.getUsername(), username);
+	}
+
+	private List<UserInfo> createDummyAdminUsers() {
+		//Arrays.asList("proj1","proj2")
+		List<UserInfo> users = Arrays.asList(
+				createUserInfo("poorao", Arrays.asList(
+						createProjectAccess("ROLE_PROJECT_ADMIN", Arrays.asList(
+								createAccessNode("project", Arrays.asList(
+										createAccessItem("proj1", "proj1"),
+										createAccessItem("proj2", "proj2")
+								))
+						))
+				)),
+				createUserInfo("andtejas", Arrays.asList(
+						createProjectAccess("ROLE_PROJECT_ADMIN", Arrays.asList(
+								createAccessNode("project", Arrays.asList(
+										createAccessItem("proj2", "proj2")
+								))
+						))
+				)),
+				createUserInfo("palaggar2", Arrays.asList(
+						createProjectAccess("ROLE_SUPERADMIN", Arrays.asList(
+								createAccessNode("project", Arrays.asList(
+										createAccessItem("proj2","proj2" )
+								))
+						))
+				))
+		);
+		return users;
+	}
+
+	private UserInfo createUserInfo(String name, List<ProjectsAccess> projectsAccess){
+		UserInfo info= new UserInfo();
+		info.setUsername(name);
+		info.setProjectsAccess(projectsAccess);
+		return info;
+	}
+	private ProjectsAccess createProjectAccess(String name, List<AccessNode> list){
+		ProjectsAccess node= new ProjectsAccess();
+		node.setRole(name);
+		node.setAccessNodes(list);
+		return node;
+	}
+
+	private AccessNode createAccessNode(String name, List<AccessItem> list){
+		AccessNode node= new AccessNode();
+		node.setAccessLevel(name);
+		node.setAccessItems(list);
+		return node;
+	}
+	private AccessItem createAccessItem(String id, String name) {
+		AccessItem accessItem = new AccessItem();
+		accessItem.setItemId(id);
+		accessItem.setItemName(name);
+		return accessItem;
 	}
 
 	@Test
@@ -484,6 +546,7 @@ public class UserBoardConfigServiceImplTest {
 				.filter(master -> (!master.getKanban() && "Backlog".equalsIgnoreCase(master.getKpiCategory())))
 				.collect(Collectors.toList()));
 		when(kpiCategoryMappingRepository.findAll()).thenReturn(kpiCategoryMappingList);
+		when(userInfoCustomRepository.findAdminUserOfProject(any())).thenReturn(new ArrayList<>());
 		UserBoardConfigDTO userBoardConfigDTO = userBoardConfigServiceImpl.getUserBoardConfig(listOfReqProjects);
 		assertEquals(userBoardConfigDTO.getScrum().get(2).getKpis().size(), 6, "Previously 4 kpis now 5");
 		assertNotNull(userBoardConfigDTO);


### PR DESCRIPTION
https://publicissapient.atlassian.net/browse/DTS-38553
when from dashbaord, all is selected and one board's kpis are hidden... then the kpis of that board from all the projects gets hidden.
but if some superadmin/ project admin, enable the board- for a few project the board still remains hidden, which is not expected, it was due to the users which are present in userboard config and are not admin, who has those kpis of that board hidden.