### PR TITLE
Fixathon - Y-Axis label update

### DIFF
--- a/common/src/main/java/com/publicissapient/kpidashboard/common/constant/CommonConstant.java
+++ b/common/src/main/java/com/publicissapient/kpidashboard/common/constant/CommonConstant.java
@@ -348,6 +348,7 @@ public final class CommonConstant {
 	public static final String MANDATORY_FIELD_MAPPING= "201";
 	public static final String TOOL_NOT_CONFIGURED= "202";
 	public static final String KPI_COMBINED_SORCE= "kpi_combined_source";
+	public static final String COUNT = "Count";
 
 
 

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/enums/KPIExcelColumn.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/enums/KPIExcelColumn.java
@@ -51,11 +51,10 @@ public enum KPIExcelColumn {
 			Arrays.asList("Project", "Repo", "Branch", "Days/Weeks", "Developer", "No Of Commit", "No of Merge")),
 
 	MEAN_TIME_TO_MERGE("kpi84", Arrays.asList("Project", "Repo", "Branch", "Merge Request Url", "Days/Weeks",
-			"PR Raised Time", "PR Merged Time", "Mean Time To Merge (In Hours)")), REPO_TOOL_MEAN_TIME_TO_MERGE(
-					"kpi158",
-					Arrays.asList("Project", "Repo", "Branch", "Days/Weeks", "Developer", "Merge Request Url",
-							"PR Raised Time", "PR Merged Time",
-							"Mean Time To Merge (In Hours)")),
+			"PR Raised Time", "PR Merged Time", "Mean Time To Merge (In Hours)")), 
+	REPO_TOOL_MEAN_TIME_TO_MERGE("kpi158", Arrays.asList("Project", "Repo", "Branch", "Days/Weeks", "Developer",
+			"Merge Request Url", "PR Raised Time", "PR Merged Time",
+			"Mean Time To Merge (In Hours)")),
 	AVERAGE_RESOLUTION_TIME(
 							"kpi83",
 							Arrays.asList("Sprint Name", "Story ID", "Issue Description", "Issue Type",

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/enums/KPIExcelColumn.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/enums/KPIExcelColumn.java
@@ -52,7 +52,7 @@ public enum KPIExcelColumn {
 
 	MEAN_TIME_TO_MERGE("kpi84", Arrays.asList("Project", "Repo", "Branch", "Merge Request Url", "Days/Weeks",
 			"PR Raised Time", "PR Merged Time", "Mean Time To Merge (In Hours)")), 
-	REPO_TOOL_MEAN_TIME_TO_MERGE("kpi158", Arrays.asList("Project", "Repo", "Branch", "Days/Weeks", "Developer",
+	REPO_TOOL_MEAN_TIME_TO_MERGE("kpi158", Arrays.asList("Project", "Repo", "Branch", "Days/Weeks", "Author",
 			"Merge Request Url", "PR Raised Time", "PR Merged Time",
 			"Mean Time To Merge (In Hours)")),
 	AVERAGE_RESOLUTION_TIME(
@@ -307,10 +307,10 @@ public enum KPIExcelColumn {
 			"Sprint Name", "Assignee", "Issue Status", "Testing Phase")),
 
 	PICKUP_TIME("kpi160",
-			Arrays.asList("Project", "Repo", "Branch", "Developer", "Days/Weeks", "Pickup Time (In Hours)")),
+			Arrays.asList("Project", "Repo", "Branch", "Author", "Days/Weeks", "Pickup Time (In Hours)")),
 
 	PR_SIZE("kpi162",
-			Arrays.asList("Project", "Repo", "Branch", "Developer", "Days/Weeks", "No of Merge",
+			Arrays.asList("Project", "Repo", "Branch", "Author", "Days/Weeks", "No of Merge",
 					"PR Size (No. of lines)")),
 
 	EPIC_PROGRESS("kpi165", Arrays.asList("Epic ID", "Epic Name", "Size(story point/hours)", "Epic Status",
@@ -330,13 +330,13 @@ public enum KPIExcelColumn {
 			"DOD Date", "DOR to DOD", "Live Date", "DOD to Live")),
 	REWORK_RATE("kpi173", Arrays.asList("Project", "Repo", "Branch", "Developer", "Days/Weeks", "Rework Rate")),
 
-	REVERT_RATE("kpi180", Arrays.asList("Project", "Repo", "Branch", "Developer", "Days/Weeks", "Revert PR",
+	REVERT_RATE("kpi180", Arrays.asList("Project", "Repo", "Branch", "Author", "Days/Weeks", "Revert PR",
 			"No of Merge", "Revert Rate")),
 
-	PR_SUCCESS_RATE("kpi182", Arrays.asList("Project", "Repo", "Branch", "Developer", "Days/Weeks", "No of Merge",
+	PR_SUCCESS_RATE("kpi182", Arrays.asList("Project", "Repo", "Branch", "Author", "Days/Weeks", "No of Merge",
 			"Closed PR", "PR Success Rate")),
 
-	PR_DECLINE_RATE("kpi181", Arrays.asList("Project", "Repo", "Branch", "Developer", "Days/Weeks", "Declined PR",
+	PR_DECLINE_RATE("kpi181", Arrays.asList("Project", "Repo", "Branch", "Author", "Days/Weeks", "Declined PR",
 			"Closed PR", "PR Decline Rate")),
 
 	RISKS_AND_DEPENDENCIES("kpi176", Arrays.asList("Issue Id", "Issue Type", "Issue Description", "Issue Status",
@@ -349,11 +349,10 @@ public enum KPIExcelColumn {
 
 	DEFECT_COUNT_BY_EXPORT("kpi178", Arrays.asList("Issue ID", "Issue Description", "Sprint Name", "Issue Type",
 			"Issue Status", "Root Cause", "Priority", "Testing Phase", "Assignee")),
-	INNOVATION_RATE("kpi185",
-			Arrays.asList("Project", "Repo", "Branch", "Developer", "Days/Weeks", "Added Lines", "Total Lines Changed",
-					"Innovation Rate")), DEFECT_RATE("kpi186",
-							Arrays.asList("Project", "Repo", "Branch", "Developer", "Days/Weeks", "Defect PR",
-									"No of Merge", "Defect Rate"));
+	INNOVATION_RATE("kpi185", Arrays.asList("Project", "Repo", "Branch", "Developer", "Days/Weeks", "Added Lines",
+			"Total Lines Changed", "Innovation Rate")), 
+	DEFECT_RATE("kpi186", Arrays.asList("Project", "Repo", "Branch", "Author", "Days/Weeks", "Defect PR", "No of Merge",
+			"Defect Rate"));
 
 	// @formatter:on
 

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/IterationReadinessServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/IterationReadinessServiceImpl.java
@@ -64,8 +64,6 @@ public class IterationReadinessServiceImpl extends JiraBacklogKPIService<Integer
 	public static final String IN_PROGRESS = "In Progress";
 	public static final String READY_FOR_DEV = "Ready for Dev";
 	public static final String NOT_REFINED = "Not Refined";
-	public static final String AXIS_LABEL_COUNT = "Count";
-	public static final String AXIS_LABEL_SP = "SP";
 	@Autowired
 	private JiraBacklogServiceR jiraService;
 	@Autowired

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/IterationReadinessServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/IterationReadinessServiceImpl.java
@@ -64,6 +64,8 @@ public class IterationReadinessServiceImpl extends JiraBacklogKPIService<Integer
 	public static final String IN_PROGRESS = "In Progress";
 	public static final String READY_FOR_DEV = "Ready for Dev";
 	public static final String NOT_REFINED = "Not Refined";
+	public static final String AXIS_LABEL_COUNT = "Count";
+	public static final String AXIS_LABEL_SP = "SP";
 	@Autowired
 	private JiraBacklogServiceR jiraService;
 	@Autowired
@@ -203,10 +205,12 @@ public class IterationReadinessServiceImpl extends JiraBacklogKPIService<Integer
 
 				IterationKpiValue issueCountIterationKpiValue = new IterationKpiValue();
 				issueCountIterationKpiValue.setFilter1(ISSUE_COUNT);
+				issueCountIterationKpiValue.setYAxisLabel(AXIS_LABEL_COUNT);
 				issueCountIterationKpiValue.setValue(issueCountDcList);
 
 				IterationKpiValue storyPointIterationKpiValue = new IterationKpiValue();
 				storyPointIterationKpiValue.setFilter1(STORY_POINT);
+				storyPointIterationKpiValue.setYAxisLabel(AXIS_LABEL_SP);
 				storyPointIterationKpiValue.setValue(storyPointDcList);
 
 				overAllIterationKpiValue.add(storyPointIterationKpiValue);

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/IterationReadinessServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/IterationReadinessServiceImpl.java
@@ -205,12 +205,12 @@ public class IterationReadinessServiceImpl extends JiraBacklogKPIService<Integer
 
 				IterationKpiValue issueCountIterationKpiValue = new IterationKpiValue();
 				issueCountIterationKpiValue.setFilter1(ISSUE_COUNT);
-				issueCountIterationKpiValue.setYAxisLabel(AXIS_LABEL_COUNT);
+				issueCountIterationKpiValue.setYAxisLabel(CommonConstant.COUNT);
 				issueCountIterationKpiValue.setValue(issueCountDcList);
 
 				IterationKpiValue storyPointIterationKpiValue = new IterationKpiValue();
 				storyPointIterationKpiValue.setFilter1(STORY_POINT);
-				storyPointIterationKpiValue.setYAxisLabel(AXIS_LABEL_SP);
+				storyPointIterationKpiValue.setYAxisLabel(CommonConstant.SP);
 				storyPointIterationKpiValue.setValue(storyPointDcList);
 
 				overAllIterationKpiValue.add(storyPointIterationKpiValue);

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseBurnUpServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseBurnUpServiceImpl.java
@@ -115,6 +115,8 @@ public class ReleaseBurnUpServiceImpl extends JiraReleaseKPIService {
 	public static final String IS_XAXIS_GAP_REQUIRED = "isXaxisGapRequired";
 	public static final String CUSTOMISED_GROUP = "customisedGroup";
 	public static final String TOTAL_AVG_VELOCITY = "totalAvgVelocity";
+	public static final String AXIS_LABEL_COUNT = "Count";
+	public static final String AXIS_LABEL_SP = "SP";
 
 	@Autowired
 	private JiraIssueRepository jiraIssueRepository;
@@ -707,10 +709,12 @@ public class ReleaseBurnUpServiceImpl extends JiraReleaseKPIService {
 			IterationKpiValue kpiValueIssueCount = new IterationKpiValue();
 			kpiValueIssueCount.setDataGroup(issueCountDataGroup);
 			kpiValueIssueCount.setFilter1(ISSUE_COUNT);
+			kpiValueIssueCount.setYAxisLabel(AXIS_LABEL_COUNT);
 			kpiValueIssueCount.setAdditionalInfo(additionalInfoIssueMap);
 			IterationKpiValue kpiValueSizeCount = new IterationKpiValue();
 			kpiValueSizeCount.setDataGroup(issueSizeCountDataGroup);
 			kpiValueSizeCount.setFilter1(STORY_POINT);
+			kpiValueSizeCount.setYAxisLabel(AXIS_LABEL_SP);
 			kpiValueSizeCount.setAdditionalInfo(additionalInfoSPMap);
 			iterationKpiValueList.add(kpiValueSizeCount);
 			iterationKpiValueList.add(kpiValueIssueCount);

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseBurnUpServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleaseBurnUpServiceImpl.java
@@ -115,8 +115,6 @@ public class ReleaseBurnUpServiceImpl extends JiraReleaseKPIService {
 	public static final String IS_XAXIS_GAP_REQUIRED = "isXaxisGapRequired";
 	public static final String CUSTOMISED_GROUP = "customisedGroup";
 	public static final String TOTAL_AVG_VELOCITY = "totalAvgVelocity";
-	public static final String AXIS_LABEL_COUNT = "Count";
-	public static final String AXIS_LABEL_SP = "SP";
 
 	@Autowired
 	private JiraIssueRepository jiraIssueRepository;
@@ -709,12 +707,12 @@ public class ReleaseBurnUpServiceImpl extends JiraReleaseKPIService {
 			IterationKpiValue kpiValueIssueCount = new IterationKpiValue();
 			kpiValueIssueCount.setDataGroup(issueCountDataGroup);
 			kpiValueIssueCount.setFilter1(ISSUE_COUNT);
-			kpiValueIssueCount.setYAxisLabel(AXIS_LABEL_COUNT);
+			kpiValueIssueCount.setYAxisLabel(CommonConstant.COUNT);
 			kpiValueIssueCount.setAdditionalInfo(additionalInfoIssueMap);
 			IterationKpiValue kpiValueSizeCount = new IterationKpiValue();
 			kpiValueSizeCount.setDataGroup(issueSizeCountDataGroup);
 			kpiValueSizeCount.setFilter1(STORY_POINT);
-			kpiValueSizeCount.setYAxisLabel(AXIS_LABEL_SP);
+			kpiValueSizeCount.setYAxisLabel(CommonConstant.SP);
 			kpiValueSizeCount.setAdditionalInfo(additionalInfoSPMap);
 			iterationKpiValueList.add(kpiValueSizeCount);
 			iterationKpiValueList.add(kpiValueIssueCount);

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleasePlanServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleasePlanServiceImpl.java
@@ -85,8 +85,6 @@ public class ReleasePlanServiceImpl extends JiraReleaseKPIService {
 	private static final String RELEASE_PLANNED = "Release planned";
 	private static final String ISSUE_COUNT = "Issue Count";
 	private static final String STORY_POINT = "Story Points";
-	public static final String AXIS_LABEL_COUNT = "Count";
-	public static final String AXIS_LABEL_SP = "SP";
 	private static final int DAYS_RANGE = 120;
 	private static final String LINE_GRAPH_TYPE = "line";
 	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -194,13 +192,13 @@ public class ReleasePlanServiceImpl extends JiraReleaseKPIService {
 				IterationKpiValue kpiValueIssueCount = new IterationKpiValue();
 				kpiValueIssueCount.setDataGroup(issueCountDataGroup);
 				kpiValueIssueCount.setFilter1(ISSUE_COUNT);
-				kpiValueIssueCount.setYAxisLabel(AXIS_LABEL_COUNT);
+				kpiValueIssueCount.setYAxisLabel(CommonConstant.COUNT);
 				kpiValueIssueCount.setAdditionalInfo(additionalInfoMap);
 
 				IterationKpiValue kpiValueSizeCount = new IterationKpiValue();
 				kpiValueSizeCount.setDataGroup(issueSizeCountDataGroup);
 				kpiValueSizeCount.setFilter1(STORY_POINT);
-				kpiValueSizeCount.setYAxisLabel(AXIS_LABEL_SP);
+				kpiValueSizeCount.setYAxisLabel(CommonConstant.SP);
 				kpiValueSizeCount.setAdditionalInfo(additionalInfoMap);
 
 				iterationKpiValueList.add(kpiValueSizeCount);

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleasePlanServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/release/ReleasePlanServiceImpl.java
@@ -85,6 +85,8 @@ public class ReleasePlanServiceImpl extends JiraReleaseKPIService {
 	private static final String RELEASE_PLANNED = "Release planned";
 	private static final String ISSUE_COUNT = "Issue Count";
 	private static final String STORY_POINT = "Story Points";
+	public static final String AXIS_LABEL_COUNT = "Count";
+	public static final String AXIS_LABEL_SP = "SP";
 	private static final int DAYS_RANGE = 120;
 	private static final String LINE_GRAPH_TYPE = "line";
 	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -192,11 +194,13 @@ public class ReleasePlanServiceImpl extends JiraReleaseKPIService {
 				IterationKpiValue kpiValueIssueCount = new IterationKpiValue();
 				kpiValueIssueCount.setDataGroup(issueCountDataGroup);
 				kpiValueIssueCount.setFilter1(ISSUE_COUNT);
+				kpiValueIssueCount.setYAxisLabel(AXIS_LABEL_COUNT);
 				kpiValueIssueCount.setAdditionalInfo(additionalInfoMap);
 
 				IterationKpiValue kpiValueSizeCount = new IterationKpiValue();
 				kpiValueSizeCount.setDataGroup(issueSizeCountDataGroup);
 				kpiValueSizeCount.setFilter1(STORY_POINT);
+				kpiValueSizeCount.setYAxisLabel(AXIS_LABEL_SP);
 				kpiValueSizeCount.setAdditionalInfo(additionalInfoMap);
 
 				iterationKpiValueList.add(kpiValueSizeCount);

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/model/IterationKpiValue.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/model/IterationKpiValue.java
@@ -51,6 +51,7 @@ public class IterationKpiValue implements Serializable {
 	private List<String> additionalGroup;
 	private Map<String, String> markerInfo;
 	private transient Map<String, Object> additionalInfo;
+	private String yAxisLabel;
 
 	public IterationKpiValue(String filter1, String filter2, List<IterationKpiData> data) {
 		this.filter1 = filter1;

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/model/KPIExcelData.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/model/KPIExcelData.java
@@ -475,4 +475,7 @@ public class KPIExcelData {
 	@JsonProperty("Change Completion Date [A]")
 	private String changeCompletionDate;
 
+	@JsonProperty("Author")
+	private String author;
+
 }

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1110/FixathonCleanJiraLastSync.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1110/FixathonCleanJiraLastSync.java
@@ -1,0 +1,31 @@
+package com.publicissapient.kpidashboard.apis.mongock.upgrade.release_1110;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+/**
+ * @author kunkambl
+ */
+@ChangeUnit(id = "fixathon_delete_jira_last_sync", order = "11103", author = "kunkambl", systemVersion = "11.1.0")
+public class FixathonCleanJiraLastSync {
+
+    private final MongoTemplate mongoTemplate;
+
+    public FixathonCleanJiraLastSync(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Execution
+    public void execution() {
+        mongoTemplate.getCollection("processor_execution_trace_log")
+                .deleteMany(new Document("processorName", "Jira"));
+    }
+
+    @RollbackExecution
+    public void rollback() {
+        // No rollback required
+    }
+}

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/repotools/service/RepoToolsConfigServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/repotools/service/RepoToolsConfigServiceImpl.java
@@ -18,6 +18,8 @@
 
 package com.publicissapient.kpidashboard.apis.repotools.service;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -277,7 +279,8 @@ public class RepoToolsConfigServiceImpl {
 				// delete only the repository
 				String deleteRepoUrl = customApiConfig.getRepoToolURL()
 						+ String.format(customApiConfig.getRepoToolDeleteRepoUrl(),
-								createProjectCode(basicProjectConfigId), tool.getRepositoryName());
+								URLEncoder.encode(createProjectCode(basicProjectConfigId), StandardCharsets.UTF_8),
+								tool.getRepositoryName());
 				httpStatus = repoToolsClient.deleteRepositories(deleteRepoUrl, customApiConfig.getRepoToolAPIKey());
 			}
 		} else {

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/util/KPIExcelUtility.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/util/KPIExcelUtility.java
@@ -1059,7 +1059,7 @@ public class KPIExcelUtility {
 				excelData.setProject(repoToolValidationData.getProjectName());
 				excelData.setRepo(repoToolValidationData.getRepoUrl());
 				excelData.setBranch(repoToolValidationData.getBranchName());
-				excelData.setDeveloper(repoToolValidationData.getDeveloperName());
+				excelData.setAuthor(repoToolValidationData.getDeveloperName());
 				excelData.setDaysWeeks(repoToolValidationData.getDate());
 				excelData.setMeanTimetoMerge(repoToolValidationData.getMeanTimeToMerge().toString());
 				excelData.setPrRaisedTime(repoToolValidationData.getPrRaisedTime());
@@ -1080,7 +1080,7 @@ public class KPIExcelUtility {
 				excelData.setProject(repoToolValidationData.getProjectName());
 				excelData.setRepo(repoToolValidationData.getProjectName());
 				excelData.setBranch(repoToolValidationData.getBranchName());
-				excelData.setDeveloper(repoToolValidationData.getDeveloperName());
+				excelData.setAuthor(repoToolValidationData.getDeveloperName());
 				excelData.setDaysWeeks(repoToolValidationData.getDate());
 				excelData.setPickupTime(String.format("%.2f", repoToolValidationData.getPickupTime()));
 				excelData.setNumberOfMerge(String.valueOf(repoToolValidationData.getMrCount()));
@@ -1097,7 +1097,7 @@ public class KPIExcelUtility {
 				excelData.setProject(repoToolValidationData.getProjectName());
 				excelData.setRepo(repoToolValidationData.getRepoUrl());
 				excelData.setBranch(repoToolValidationData.getBranchName());
-				excelData.setDeveloper(repoToolValidationData.getDeveloperName());
+				excelData.setAuthor(repoToolValidationData.getDeveloperName());
 				excelData.setDaysWeeks(repoToolValidationData.getDate());
 				excelData.setPrSize(String.valueOf(repoToolValidationData.getPrSize()));
 				excelData.setNumberOfMerge(String.valueOf(repoToolValidationData.getMrCount()));
@@ -1148,7 +1148,7 @@ public class KPIExcelUtility {
 				excelData.setProject(repoToolValidationData.getProjectName());
 				excelData.setRepo(repoToolValidationData.getRepoUrl());
 				excelData.setBranch(repoToolValidationData.getBranchName());
-				excelData.setDeveloper(repoToolValidationData.getDeveloperName());
+				excelData.setAuthor(repoToolValidationData.getDeveloperName());
 				excelData.setDaysWeeks(repoToolValidationData.getDate());
 				excelData.setNumberOfMerge(String.valueOf(repoToolValidationData.getMrCount()));
 				excelData.setDefectPRs(repoToolValidationData.getKpiPRs());
@@ -1183,7 +1183,7 @@ public class KPIExcelUtility {
                 excelData.setProject(repoToolValidationData.getProjectName());
                 excelData.setRepo(repoToolValidationData.getRepoUrl());
                 excelData.setBranch(repoToolValidationData.getBranchName());
-                excelData.setDeveloper(repoToolValidationData.getDeveloperName());
+                excelData.setAuthor(repoToolValidationData.getDeveloperName());
                 excelData.setDaysWeeks(repoToolValidationData.getDate());
                 excelData.setRevertRate(roundingOff(repoToolValidationData.getRevertRate()));
                 excelData.setNumberOfMerge(String.valueOf(repoToolValidationData.getMrCount()));
@@ -1202,7 +1202,7 @@ public class KPIExcelUtility {
                 excelData.setProject(repoToolValidationData.getProjectName());
                 excelData.setRepo(repoToolValidationData.getRepoUrl());
                 excelData.setBranch(repoToolValidationData.getBranchName());
-                excelData.setDeveloper(repoToolValidationData.getDeveloperName());
+                excelData.setAuthor(repoToolValidationData.getDeveloperName());
                 excelData.setDaysWeeks(repoToolValidationData.getDate());
                 excelData.setPRSccessRate(roundingOff(repoToolValidationData.getPRSuccessRate()));
                 excelData.setNumberOfMerge(String.valueOf(repoToolValidationData.getKpiPRs()));
@@ -1222,7 +1222,7 @@ public class KPIExcelUtility {
 				excelData.setProject(repoToolValidationData.getProjectName());
 				excelData.setRepo(repoToolValidationData.getRepoUrl());
 				excelData.setBranch(repoToolValidationData.getBranchName());
-				excelData.setDeveloper(repoToolValidationData.getDeveloperName());
+				excelData.setAuthor(repoToolValidationData.getDeveloperName());
 				excelData.setDaysWeeks(repoToolValidationData.getDate());
 				excelData.setPrDeclineRate(roundingOff(repoToolValidationData.getPrDeclineRate()));
 				excelData.setDeclinedPRs(repoToolValidationData.getKpiPRs());


### PR DESCRIPTION
Release Burnup KPI- When we choose SP, the Y axis does not switch to SP. At the moment, only the issue count is being displayed.