### PR TITLE
DTS-44135: Clarios epicLink parse issue fix

### DIFF
--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1300/TraceLogChangeUnit.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1300/TraceLogChangeUnit.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 CapitalOne, LLC.
+ * Further development Copyright 2022 Sapient Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.publicissapient.kpidashboard.apis.mongock.upgrade.release_1300;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+/**
+ * Fix for DTS-44135: Clean and re-fetch Jira issue epicLinked field data
+ * 
+ * @author shunaray
+ */
+@ChangeUnit(id = "jira_trace_clean", order = "13002", author = "shunaray", systemVersion = "13.0.0")
+public class TraceLogChangeUnit {
+
+	private final MongoTemplate mongoTemplate;
+
+	public TraceLogChangeUnit(MongoTemplate mongoTemplate) {
+		this.mongoTemplate = mongoTemplate;
+	}
+
+	@Execution
+	public void execution() {
+		deleteProcessorExecutionTraceLog();
+	}
+
+	public void deleteProcessorExecutionTraceLog() {
+		mongoTemplate.getCollection("processor_execution_trace_log").deleteMany(
+				new Document("basicProjectConfigId", "6762bc10ed9a4560dc380a67").append("processorName", "Jira"));
+	}
+
+	@RollbackExecution
+	public void rollback() {
+		// doesn't require rollback
+	}
+}

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1300/TraceLogChangeUnit.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1300/TraceLogChangeUnit.java
@@ -29,7 +29,7 @@ import io.mongock.api.annotations.RollbackExecution;
  * 
  * @author shunaray
  */
-@ChangeUnit(id = "jira_trace_clean", order = "13002", author = "shunaray", systemVersion = "13.0.0")
+@ChangeUnit(id = "jira_trace_clean", order = "13003", author = "shunaray", systemVersion = "13.0.0")
 public class TraceLogChangeUnit {
 
 	private final MongoTemplate mongoTemplate;

--- a/processors/jira/src/main/java/com/publicissapient/kpidashboard/jira/processor/JiraIssueProcessorImpl.java
+++ b/processors/jira/src/main/java/com/publicissapient/kpidashboard/jira/processor/JiraIssueProcessorImpl.java
@@ -57,6 +57,7 @@ import com.atlassian.jira.rest.client.api.domain.IssueLink;
 import com.atlassian.jira.rest.client.api.domain.IssueType;
 import com.atlassian.jira.rest.client.api.domain.User;
 import com.atlassian.jira.rest.client.api.domain.Version;
+import com.atlassian.jira.rest.client.internal.json.JsonParseUtil;
 import com.publicissapient.kpidashboard.common.constant.CommonConstant;
 import com.publicissapient.kpidashboard.common.constant.NormalizedJira;
 import com.publicissapient.kpidashboard.common.constant.ProcessorConstants;
@@ -219,9 +220,17 @@ public class JiraIssueProcessorImpl implements JiraIssueProcessor {
 	}
 
 	private void setEpicLinked(FieldMapping fieldMapping, JiraIssue jiraIssue, Map<String, IssueField> fields) {
-		if (StringUtils.isNotEmpty(fieldMapping.getEpicLink()) && fields.get(fieldMapping.getEpicLink()) != null &&
-				fields.get(fieldMapping.getEpicLink()).getValue() != null) {
-			jiraIssue.setEpicLinked(fields.get((fieldMapping.getEpicLink()).trim()).getValue().toString());
+		if (StringUtils.isNotEmpty(fieldMapping.getEpicLink()) && fields.get(fieldMapping.getEpicLink()) != null
+				&& fields.get(fieldMapping.getEpicLink()).getValue() != null) {
+			final Object epicLink = fields.get((fieldMapping.getEpicLink()).trim()).getValue();
+			if (epicLink instanceof String) {
+				jiraIssue.setEpicLinked(epicLink.toString());
+			} else if (epicLink instanceof JSONObject epicLinkJson) {
+				String epicKey = JsonParseUtil.getOptionalString(epicLinkJson, "key");
+				if (epicKey != null) {
+					jiraIssue.setEpicLinked(epicKey);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
https://publicissapient.atlassian.net/browse/DTS-44135

Root cause : 

Transition to 'Parent' Field: The 'Epic Link' and 'Parent Link' fields in company-managed projects will be replaced with the 'Parent' field, which is already used in team-managed projects. This change aims to provide a consistent experience for managing issue hierarchies.

