### PR TITLE
DTS-45722: Reverting the active sprint filter code.

### DIFF
--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/BacklogEpicProgressServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/BacklogEpicProgressServiceImpl.java
@@ -138,7 +138,8 @@ public class BacklogEpicProgressServiceImpl extends JiraBacklogKPIService<Intege
 		Map<String, Object> resultListMap = new HashMap<>();
 		if (null != leafNode) {
 			log.info("Backlog Epic Progress -> Requested sprint : {}", leafNode.getName());
-			List<JiraIssue> totalJiraIssue = getBackLogJiraIssuesFromBaseClass();
+			List<JiraIssue> totalJiraIssue = jiraIssueRepository
+					.findByBasicProjectConfigId(leafNode.getProjectFilter().getBasicProjectConfigId().toString());
 			resultListMap.put(TOTAL_ISSUES, totalJiraIssue);
 			// get Epics Linked to backlogStories stories
 			final List<String> epicKeyList = totalJiraIssue.stream().map(JiraIssue::getEpicLinked).toList();

--- a/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/UnlinkedWorkItemsServiceImpl.java
+++ b/customapi/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/UnlinkedWorkItemsServiceImpl.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -307,10 +306,8 @@ public class UnlinkedWorkItemsServiceImpl extends JiraBacklogKPIService<Integer,
 		String startDate = dateRange.getStartDate().format(DATE_FORMATTER);
 		String endDate = dateRange.getEndDate().format(DATE_FORMATTER);
 		Map<String, Object> returnMap = fetchKPIDataFromDb(leafNode, startDate, endDate, kpiRequest);
-		//for filtering active sprint jiraIssues
-		Set<String> activeSprintIssues = getActiveSprintJiraIssuesFromBaseClass();
+
 		List<String> storiesInProject = (List<String>) returnMap.get(TEST_WITHOUT_STORY_LIST);
-		storiesInProject.forEach(activeSprintIssues::remove);
 		List<TestCaseDetails> totalTestNonRegression = (List<TestCaseDetails>) returnMap.get(TEST_WITHOUT_STORY_TEST_CASES);
 		List<TestCaseDetails> testWithoutStory = totalTestNonRegression.stream()
 				.filter(
@@ -318,9 +315,7 @@ public class UnlinkedWorkItemsServiceImpl extends JiraBacklogKPIService<Integer,
 				.collect(Collectors.toList());
 
 		List<JiraIssue> totalDefects = checkPriority((List<JiraIssue>) returnMap.get(DEFECTS_WITHOUT_STORY_DEFECTS_LIST));
-		totalDefects.removeIf(j-> activeSprintIssues.contains(j.getNumber()));
-		List<String> totalStories = (List<String>) returnMap.get(DEFECTS_WITHOUT_STORY_LIST);
-		totalStories.forEach(activeSprintIssues::remove);
+		List<JiraIssue> totalStories = (List<JiraIssue>) returnMap.get(DEFECTS_WITHOUT_STORY_LIST);
 		List<JiraIssue> defectWithoutStory = new ArrayList<>();
 		defectWithoutStory.addAll(totalDefects.stream()
 				.filter(f -> !CollectionUtils.containsAny(f.getDefectStoryID(), totalStories)).collect(Collectors.toList()));

--- a/customapi/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/BacklogEpicProgressServiceImplTest.java
+++ b/customapi/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/BacklogEpicProgressServiceImplTest.java
@@ -153,14 +153,14 @@ public class BacklogEpicProgressServiceImplTest {
 		Set<JiraIssue> epic = jiraIssueArrayList.stream()
 				.filter(jiraIssue -> jiraIssue.getTypeName().equalsIgnoreCase("Epic")).collect(Collectors.toSet());
 		when(jiraService.getJiraIssueReleaseForProject()).thenReturn(jiraIssueReleaseStatusList.get(0));
-		when(jiraService.getJiraIssuesForCurrentSprint()).thenReturn(jiraIssueArrayList);
 		Map<String, Object> resultListMap = epicProgressService.fetchKPIDataFromDb(
 				treeAggregatorDetail.getMapOfListOfProjectNodes().get("project").get(0), "", "", kpiRequest);
 
 		Assertions.assertThat(resultListMap).isNotEmpty();
 		Assertions.assertThat(resultListMap.containsKey(TOTAL_ISSUES)).isTrue();
-		Assertions.assertThat(((List<JiraIssue>) resultListMap.get(TOTAL_ISSUES)).size()).isGreaterThan(0);
+		Assertions.assertThat(((List<JiraIssue>) resultListMap.get(TOTAL_ISSUES)).size()).isEqualTo(0);
 		Assertions.assertThat(resultListMap.containsKey(EPIC_LINKED)).isTrue();
+		Assertions.assertThat(((Set<JiraIssue>) resultListMap.get(EPIC_LINKED)).size()).isEqualTo(0);
 		Assertions.assertThat(resultListMap.containsKey(RELEASE_JIRA_ISSUE_STATUS)).isTrue();
 	}
 
@@ -248,7 +248,6 @@ public class BacklogEpicProgressServiceImplTest {
 				.filter(jiraIssue -> jiraIssue.getTypeName().equalsIgnoreCase("Epic")).collect(Collectors.toSet());
 		jiraIssueArrayList.stream().filter(jiraIssue -> !jiraIssue.getTypeName().equalsIgnoreCase("Epic"))
 				.forEach(jiraIssue -> jiraIssue.setEpicLinked("EPIC-1"));
-		when(jiraService.getJiraIssuesForCurrentSprint()).thenReturn(jiraIssueArrayList);
 		when(jiraService.getJiraIssueReleaseForProject()).thenReturn(jiraIssueReleaseStatusList.get(0));
 		KpiElement kpiElement = epicProgressService.getKpiData(kpiRequest, kpiRequest.getKpiList().get(0),
 				treeAggregatorDetail.getMapOfListOfProjectNodes().get("project").get(0));

--- a/customapi/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/DefectReopenRateServiceImplTest.java
+++ b/customapi/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/DefectReopenRateServiceImplTest.java
@@ -20,6 +20,7 @@ package com.publicissapient.kpidashboard.apis.jira.scrum.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.publicissapient.kpidashboard.apis.appsetting.service.ConfigHelperService;
@@ -108,8 +110,6 @@ public class DefectReopenRateServiceImplTest {
 				.newInstance("/json/default/iteration/jira_issue_custom_history.json");
 		totalJiraIssueList = jiraIssueDataFactory.getJiraIssues();
 		totalJiraIssueHistoryList = jiraIssueHistoryDataFactory.getUniqueJiraIssueCustomHistory();
-		when(jiraService.getJiraIssuesForCurrentSprint()).thenReturn(totalJiraIssueList);
-		when(jiraService.getJiraIssuesCustomHistoryForCurrentSprint()).thenReturn(totalJiraIssueHistoryList);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -117,6 +117,10 @@ public class DefectReopenRateServiceImplTest {
 	public void testGetKpiData() throws ApplicationException {
 		TreeAggregatorDetail treeAggregatorDetail = KPIHelperUtil.getTreeLeafNodesGroupedByFilter(kpiRequest,
 				accountHierarchyDataList, new ArrayList<>(), "hierarchyLevelOne", 5);
+		Mockito.doReturn(totalJiraIssueList).when(jiraIssueRepository).findIssuesByFilterAndProjectMapFilter(anyMap(),
+				anyMap());
+		Mockito.doReturn(totalJiraIssueHistoryList).when(jiraIssueCustomHistoryRepository)
+				.findByFilterAndFromStatusMap(anyMap(), anyMap());
 		try {
 
 			KpiElement kpiElement = defectReopenRateService.getKpiData(kpiRequest, kpiRequest.getKpiList().get(0),
@@ -128,7 +132,7 @@ public class DefectReopenRateServiceImplTest {
 			IterationKpiValue iterationKpiValue = iterationKpiValues.stream()
 					.filter(kpiValue -> "Overall".equals(kpiValue.getFilter1())).findFirst().get();
 			assertNotNull(iterationKpiValue);
-			assertEquals(Optional.of(0.0d).get(), iterationKpiValue.getData().get(0).getValue());
+			assertEquals(Optional.of(3.0d).get(), iterationKpiValue.getData().get(0).getValue());
 		} catch (ApplicationException applicationException) {
 
 		}


### PR DESCRIPTION
Change-log: Exclude active sprint data from backlog feature.

https://publicissapient.atlassian.net/browse/DTS-45722?linkSource=email