### PR TITLE
DTS-45797 Implement the guest authentication flow

### DIFF
--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/config/WebSecurityConfig.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/config/WebSecurityConfig.java
@@ -18,20 +18,12 @@
 
 package com.publicissapient.kpidashboard.apis.config;
 
-import java.io.ByteArrayInputStream;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
+import com.publicissapient.kpidashboard.apis.filters.CorsFilter;
+import com.publicissapient.kpidashboard.apis.filters.JwtAuthenticationFilter;
+import com.publicissapient.kpidashboard.apis.filters.standard.StandardLoginRequestFilter;
+import com.publicissapient.kpidashboard.apis.filters.standard.handlers.CustomAuthenticationFailureHandler;
+import com.publicissapient.kpidashboard.apis.filters.standard.handlers.CustomAuthenticationSuccessHandler;
+import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.saml2.Saml2RelyingPartyProperties;
 import org.springframework.context.annotation.Bean;
@@ -52,13 +44,19 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import com.publicissapient.kpidashboard.apis.filters.CorsFilter;
-import com.publicissapient.kpidashboard.apis.filters.JwtAuthenticationFilter;
-import com.publicissapient.kpidashboard.apis.filters.standard.StandardLoginRequestFilter;
-import com.publicissapient.kpidashboard.apis.filters.standard.handlers.CustomAuthenticationFailureHandler;
-import com.publicissapient.kpidashboard.apis.filters.standard.handlers.CustomAuthenticationSuccessHandler;
-
-import lombok.AllArgsConstructor;
+import java.io.ByteArrayInputStream;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Configuration
 @AllArgsConstructor
@@ -86,13 +84,25 @@ public class WebSecurityConfig {
 			httpSecurityHeadersConfigurer.contentSecurityPolicy(contentSecurityPolicyConfig -> contentSecurityPolicyConfig
 					.policyDirectives(authConfig.getContentSecurityPolicy()));
 		});
-		http.authorizeHttpRequests(authz -> authz.requestMatchers(HttpMethod.OPTIONS).permitAll().requestMatchers("/login")
-				.permitAll().requestMatchers("/register-user").permitAll().requestMatchers("/forgot-password").permitAll()
-				.requestMatchers("/reset-password").permitAll().requestMatchers("/change-password").permitAll()
-				.requestMatchers("/validateEmailToken").permitAll().requestMatchers("/verifyUser").permitAll()
-				.requestMatchers("/user-info").permitAll().requestMatchers("/users/**").permitAll()
-				.requestMatchers("/sso-logout").permitAll().requestMatchers("/user-approvals/pending").permitAll()
-				.requestMatchers("/approve").permitAll().requestMatchers("/reject").permitAll().anyRequest().authenticated())
+		http.authorizeHttpRequests(
+				authz -> authz.requestMatchers(HttpMethod.OPTIONS).permitAll()
+						.requestMatchers("/login").permitAll()
+						.requestMatchers("/register-user").permitAll()
+						.requestMatchers("/forgot-password").permitAll()
+						.requestMatchers("/reset-password").permitAll()
+						.requestMatchers("/change-password").permitAll()
+						.requestMatchers("/validateEmailToken").permitAll()
+						.requestMatchers("/verifyUser").permitAll()
+						.requestMatchers("/user-info").permitAll()
+						.requestMatchers("/users/**").permitAll()
+						.requestMatchers("/sso-logout").permitAll()
+						.requestMatchers("/user-approvals/pending").permitAll()
+						.requestMatchers("/approve").permitAll()
+						.requestMatchers("/reject").permitAll()
+						.requestMatchers("/guest-login").permitAll()
+						.requestMatchers("/guest-logout").permitAll()
+						.anyRequest()
+						.authenticated())
 				.saml2Login((saml2) -> saml2.loginProcessingUrl("/saml/SSO"))
 				.saml2Logout((saml2) -> saml2.logoutRequest((request) -> request.logoutUrl("/saml/logout")))
 				.saml2Logout((saml2) -> saml2.logoutResponse((response) -> response.logoutUrl("/saml/SingleLogout")))

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/controller/GuestUserController.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/controller/GuestUserController.java
@@ -17,6 +17,7 @@
 package com.publicissapient.kpidashboard.apis.controller;
 
 import com.publicissapient.kpidashboard.apis.service.GuestUserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,17 @@ public class GuestUserController {
     ) {
         guestUserService.loginUserAsGuest(displayName, response);
 
+        return new RedirectView(redirectUri);
+    }
+
+    @GetMapping("/guest-logout")
+    public RedirectView guestLogout(
+            @RequestParam String redirectUri,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        guestUserService.logoutGuestUser(request, response);
+        
         return new RedirectView(redirectUri);
     }
 }

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/controller/GuestUserController.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/controller/GuestUserController.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2024 <Sapient Corporation>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the
+ *  License.
+ */
+
+package com.publicissapient.kpidashboard.apis.controller;
+
+import com.publicissapient.kpidashboard.apis.service.GuestUserService;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RestController
+@AllArgsConstructor
+@Slf4j
+public class GuestUserController {
+
+    private final GuestUserService guestUserService;
+
+    @GetMapping("/guest-login")
+    public RedirectView guestLogin(
+            @RequestParam String displayName,
+            @RequestParam String redirectUri,
+            @NotNull HttpServletResponse response
+    ) {
+        guestUserService.loginUserAsGuest(displayName, response);
+
+        return new RedirectView(redirectUri);
+    }
+}

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/controller/GuestUserController.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/controller/GuestUserController.java
@@ -18,7 +18,6 @@ package com.publicissapient.kpidashboard.apis.controller;
 
 import com.publicissapient.kpidashboard.apis.service.GuestUserService;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,7 +36,7 @@ public class GuestUserController {
     public RedirectView guestLogin(
             @RequestParam String displayName,
             @RequestParam String redirectUri,
-            @NotNull HttpServletResponse response
+            HttpServletResponse response
     ) {
         guestUserService.loginUserAsGuest(displayName, response);
 

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/GuestUserService.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/GuestUserService.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2024 <Sapient Corporation>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the
+ *  License.
+ */
+
+package com.publicissapient.kpidashboard.apis.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface GuestUserService {
+    void loginUserAsGuest(String guestDisplayName, HttpServletResponse response);
+}

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/GuestUserService.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/GuestUserService.java
@@ -16,8 +16,11 @@
 
 package com.publicissapient.kpidashboard.apis.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface GuestUserService {
     void loginUserAsGuest(String guestDisplayName, HttpServletResponse response);
+
+    void logoutGuestUser(HttpServletRequest request, HttpServletResponse response);
 }

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/TokenAuthenticationService.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/TokenAuthenticationService.java
@@ -18,16 +18,14 @@
 
 package com.publicissapient.kpidashboard.apis.service;
 
-import java.util.Collection;
-import java.util.List;
-
+import com.publicissapient.kpidashboard.apis.enums.AuthType;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
-import com.publicissapient.kpidashboard.apis.enums.AuthType;
-
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotNull;
+import java.util.Collection;
+import java.util.List;
 
 public interface TokenAuthenticationService {
 
@@ -45,4 +43,7 @@ public interface TokenAuthenticationService {
 	Collection<GrantedAuthority> createAuthorities(List<String> roles);
 
 	String extractUsernameFromAuthentication(Authentication authentication);
+
+	// will create the following cookies: authCookie, authCookie_EXPIRY and guestDisplayName
+	void addGuestCookies(String guestDisplayName, String jwt, HttpServletResponse response);
 }

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/TokenAuthenticationService.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/TokenAuthenticationService.java
@@ -19,6 +19,7 @@
 package com.publicissapient.kpidashboard.apis.service;
 
 import com.publicissapient.kpidashboard.apis.enums.AuthType;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.security.core.Authentication;
@@ -46,4 +47,7 @@ public interface TokenAuthenticationService {
 
 	// will create the following cookies: authCookie, authCookie_EXPIRY and guestDisplayName
 	void addGuestCookies(String guestDisplayName, String jwt, HttpServletResponse response);
+
+	// will delete the following cookies: authCookie, authCookie_EXPIRY and guestDisplayName
+	void deleteGuestCookies(HttpServletRequest request, HttpServletResponse response);
 }

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/GuestUserServiceImpl.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/GuestUserServiceImpl.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2024 <Sapient Corporation>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the
+ *  License.
+ */
+
+package com.publicissapient.kpidashboard.apis.service.impl;
+
+import com.publicissapient.kpidashboard.apis.enums.AuthType;
+import com.publicissapient.kpidashboard.apis.service.GuestUserService;
+import com.publicissapient.kpidashboard.apis.service.TokenAuthenticationService;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+@Validated
+public class GuestUserServiceImpl implements GuestUserService {
+
+    private static final String ROLE_GUEST = "GUEST";
+
+    private final TokenAuthenticationService tokenAuthenticationService;
+
+    @Override
+    public void loginUserAsGuest(
+            @NotEmpty String guestDisplayName,
+            @NotNull HttpServletResponse response
+    ) {
+        String jwt = tokenAuthenticationService.createJWT(
+                UUID.randomUUID().toString(),
+                AuthType.STANDARD,
+                tokenAuthenticationService.createAuthorities(List.of(ROLE_GUEST))
+        );
+        tokenAuthenticationService.addGuestCookies(guestDisplayName, jwt, response);
+    }
+}

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/GuestUserServiceImpl.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/GuestUserServiceImpl.java
@@ -19,6 +19,7 @@ package com.publicissapient.kpidashboard.apis.service.impl;
 import com.publicissapient.kpidashboard.apis.enums.AuthType;
 import com.publicissapient.kpidashboard.apis.service.GuestUserService;
 import com.publicissapient.kpidashboard.apis.service.TokenAuthenticationService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,5 +48,10 @@ public class GuestUserServiceImpl implements GuestUserService {
                 tokenAuthenticationService.createAuthorities(List.of(ROLE_GUEST))
         );
         tokenAuthenticationService.addGuestCookies(guestDisplayName, jwt, response);
+    }
+
+    @Override
+    public void logoutGuestUser(HttpServletRequest request, HttpServletResponse response) {
+        tokenAuthenticationService.deleteGuestCookies(request, response);
     }
 }

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/GuestUserServiceImpl.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/GuestUserServiceImpl.java
@@ -25,7 +25,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 import java.util.UUID;
@@ -33,7 +32,7 @@ import java.util.UUID;
 @Service
 @Slf4j
 @AllArgsConstructor
-@Validated
+//@Validated
 public class GuestUserServiceImpl implements GuestUserService {
 
     private static final String ROLE_GUEST = "GUEST";

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/GuestUserServiceImpl.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/GuestUserServiceImpl.java
@@ -20,8 +20,6 @@ import com.publicissapient.kpidashboard.apis.enums.AuthType;
 import com.publicissapient.kpidashboard.apis.service.GuestUserService;
 import com.publicissapient.kpidashboard.apis.service.TokenAuthenticationService;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,7 +30,6 @@ import java.util.UUID;
 @Service
 @Slf4j
 @AllArgsConstructor
-//@Validated
 public class GuestUserServiceImpl implements GuestUserService {
 
     private static final String ROLE_GUEST = "GUEST";
@@ -41,8 +38,8 @@ public class GuestUserServiceImpl implements GuestUserService {
 
     @Override
     public void loginUserAsGuest(
-            @NotEmpty String guestDisplayName,
-            @NotNull HttpServletResponse response
+            String guestDisplayName,
+            HttpServletResponse response
     ) {
         String jwt = tokenAuthenticationService.createJWT(
                 UUID.randomUUID().toString(),

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/TokenAuthenticationServiceImpl.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/service/impl/TokenAuthenticationServiceImpl.java
@@ -29,6 +29,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -133,4 +134,14 @@ public class TokenAuthenticationServiceImpl implements TokenAuthenticationServic
 		CookieUtil.addCookie(response, CookieUtil.GUEST_DISPLAY_NAME_COOKIE_NAME, guestDisplayName,
 				cookieConfig.getDuration(), cookieConfig.getDomain(), cookieConfig.getIsSameSite(), cookieConfig.getIsSecure());
 	}
+
+    @Override
+    public void deleteGuestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtil.deleteCookie(request, response, cookieConfig.getDomain(), CookieUtil.COOKIE_NAME,
+                CookieUtil.API_COOKIE_PATH);
+        CookieUtil.deleteCookie(request, response, cookieConfig.getDomain(), CookieUtil.EXPIRY_COOKIE_NAME,
+                CookieUtil.API_COOKIE_PATH);
+        CookieUtil.deleteCookie(request, response, cookieConfig.getDomain(), CookieUtil.GUEST_DISPLAY_NAME_COOKIE_NAME,
+                CookieUtil.API_COOKIE_PATH);
+    }
 }

--- a/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/util/CookieUtil.java
+++ b/central-auth-service/authapi/src/main/java/com/publicissapient/kpidashboard/apis/util/CookieUtil.java
@@ -17,14 +17,14 @@
  ******************************************************************************/
 package com.publicissapient.kpidashboard.apis.util;
 
-import java.util.Arrays;
-import java.util.Optional;
-
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Optional;
 
 @NoArgsConstructor
 public class CookieUtil {
@@ -37,6 +37,8 @@ public class CookieUtil {
 	public static final String EXPIRY_COOKIE_NAME = COOKIE_NAME + "_EXPIRY";
 
 	public static final String USERNAME_COOKIE_NAME = "samlUsernameCookie";
+
+	public static final String GUEST_DISPLAY_NAME_COOKIE_NAME = "guestDisplayName";
 
 	private static final String SAME_SITE_ATTRIBUTE = "SameSite";
 

--- a/central-auth-service/authapi/src/main/resources/application.properties
+++ b/central-auth-service/authapi/src/main/resources/application.properties
@@ -115,7 +115,7 @@ auth.notificationSubject.userVerificationFailed=User Verification Token Expired
 
 auth.secret=${SIGNATURE_SECRET}
 auth.auth-endpoints.authenticated-endpoints=**
-auth.auth-endpoints.public-endpoints=/saml-login,/saml-logout,/login,/register-user,/forgot-password,/reset-password,/verifyUser,/validateEmailToken,/guest-login
+auth.auth-endpoints.public-endpoints=/saml-login,/saml-logout,/login,/register-user,/forgot-password,/reset-password,/verifyUser,/validateEmailToken,/guest-login,/guest-logout
 auth.auth-endpoints.external-endpoints=/user-approvals/pending,/approve,/reject,/change-password
 
 #Purpose of properties : property used to server to server API call

--- a/central-auth-service/authapi/src/main/resources/application.properties
+++ b/central-auth-service/authapi/src/main/resources/application.properties
@@ -115,7 +115,7 @@ auth.notificationSubject.userVerificationFailed=User Verification Token Expired
 
 auth.secret=${SIGNATURE_SECRET}
 auth.auth-endpoints.authenticated-endpoints=**
-auth.auth-endpoints.public-endpoints=/saml-login,/saml-logout,/login,/register-user,/forgot-password,/reset-password,/verifyUser,/validateEmailToken
+auth.auth-endpoints.public-endpoints=/saml-login,/saml-logout,/login,/register-user,/forgot-password,/reset-password,/verifyUser,/validateEmailToken,/guest-login
 auth.auth-endpoints.external-endpoints=/user-approvals/pending,/approve,/reject,/change-password
 
 #Purpose of properties : property used to server to server API call


### PR DESCRIPTION
The PR contains the merging of the guest authentication flow from an auth service which will no longer be used to PSKnowHow auth service.

Implemented two public endpoints "/guest-login" and "/guest-logout" which are responsible for setting / removing some guest specific cookies and perform a redirect to another URI.